### PR TITLE
feat(order): using go args to pass .env path to main.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ order.test.coverage_render:
 
 .PHONY:order.run
 order.run: 
-	cd services/order && go run cmd/server/main.go
+	cd services/order && go run cmd/server/main.go ./../../.env
 
 .PHONY:order.worker.run
 order.worker.run:

--- a/deploys/docker-compose.yaml
+++ b/deploys/docker-compose.yaml
@@ -1,4 +1,14 @@
 services:
+  # order-service:
+  #   container_name: saga-order
+  #   image: ghcr.io/trungtho/saga-playground/order-service:latest
+  #   restart: on-failure
+  #   networks:
+  #     - saga-playground
+  #   ports:
+  #     - ${ORDER_SERVICE_PORT}:${ORDER_SERVICE_PORT}
+  #   volumes:
+  #     - .env:.
   db: # using 1 shared DB for simplicity, in prod each service should have its own dedicated DB
     container_name: saga-database
     image: debezium/postgres:14-alpine # customized image for logical replication and Debezium privilege

--- a/services/order/cmd/server/main.go
+++ b/services/order/cmd/server/main.go
@@ -199,7 +199,16 @@ func initDbConnection(config *util.Config) (db.DBStore, *pgxpool.Pool) {
 }
 
 func loadConfig() util.Config {
-	config, err := util.LoadConfig("./../../.env")
+	allArgs := os.Args
+	envPath := allArgs[1]
+
+	if len(envPath) == 0 {
+		log.Fatalln("Missing path to .env file")
+	}
+
+	log.Println("Loading env from", envPath)
+
+	config, err := util.LoadConfig(envPath)
 	if err != nil {
 		log.Fatalln("Can not load config from env ", err)
 	}


### PR DESCRIPTION
- using args to pass `.env` path to loadConfig in main.go instead of using hardcoded string
- update Makefile with corresponding .env path