### PR TITLE
fix(order): containers connectivity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ restart: down up
 
 .PHONY: up
 up: start
+	podman -c $(VM_NAME) compose -f deploys/docker-compose.yaml pull --ignore-pull-failures	
 	podman -c $(VM_NAME) compose -f deploys/docker-compose.yaml up -d
 
 .PHONY: down

--- a/deploys/docker-compose.yaml
+++ b/deploys/docker-compose.yaml
@@ -3,14 +3,23 @@ services:
     container_name: saga-order
     image: ghcr.io/trungtho/saga-playground/order-service:latest
     restart: on-failure
-    networks:
-      - saga-playground
     ports:
       - ${ORDER_SERVICE_PORT}:${ORDER_SERVICE_PORT}
+      - ${ORDER_SERVICE_GRPC_PORT}:${ORDER_SERVICE_GRPC_PORT}
     pull_policy: always
+    # pull_policy: never
     volumes:
       - ./container.env:/container.env
     command: ["container.env"]
+    depends_on:
+      db:
+        condition: service_healthy
+        restart: true
+      kafka-1:
+        condition: service_healthy
+        restart: true
+    networks:
+      - saga-playground
 
   # debugger:
   #   container_name: saga-debugger
@@ -189,7 +198,7 @@ services:
     restart: on-failure
     image: quay.io/debezium/debezium-ui:1.7.2.Final
     ports:
-      - "8081:8080"
+      - "${DEBEZIUM_UI_PORT}:8080"
     environment:
       - KAFKA_CONNECT_URIS=http://debezium-connector:8083
     depends_on:

--- a/services/order/Dockerfile
+++ b/services/order/Dockerfile
@@ -38,4 +38,5 @@ RUN upx --best --lzma order-service
 FROM scratch
 COPY --from=builder /app/order-service /order-service
 COPY --from=builder /app/db/migrations /db/migrations
+WORKDIR /
 ENTRYPOINT ["/order-service"]

--- a/services/order/cmd/server/main.go
+++ b/services/order/cmd/server/main.go
@@ -148,8 +148,8 @@ func startRestServer(ctx context.Context,
 	config util.Config,
 ) {
 	wg.Go(func() error {
-		err := restServer.Start(fmt.Sprintf("%s:%s",
-			config.ORDER_SERVICE_HOST, config.ORDER_SERVICE_PORT))
+		err := restServer.Start(fmt.Sprintf(":%s",
+			config.ORDER_SERVICE_PORT))
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatalln("Can not start Rest Server ", err)
 			return err


### PR DESCRIPTION
- fix order golang RESTful server is unreachable outside of its container network, detail issue: https://stackoverflow.com/questions/72910177/curl-56-recv-failure-connection-reset-by-peer-in-golang-with-docker
- add init-vm to Makefile for podman machine init
- add depend_on for order service container to wait for kafka & db to be read first